### PR TITLE
attribute_escape -> esc_attr

### DIFF
--- a/wpomatic.php
+++ b/wpomatic.php
@@ -77,7 +77,7 @@ class WPOMatic {
 
     # Cron command / url
     $this->cron_url = $this->pluginpath . '/cron.php?code=' . get_option('wpo_croncode');
-    $this->cron_command = attribute_escape('*/20 * * * * '. $this->getCommand() . ' ' . $this->cron_url);
+    $this->cron_command = esc_attr('*/20 * * * * '. $this->getCommand() . ' ' . $this->cron_url);
   }
 
   /**
@@ -1945,7 +1945,7 @@ class WPOMatic {
         $this->adminUpdateCampaignPosts($id, array('post_author' => $authorid));
       } else {
         $this->errno = 1;
-        $this->errors = array('tools' => array(sprintf(__('Author %s not found', 'wpomatic'), attribute_escape($_REQUEST['campaign_tool_changeauthor']))));
+        $this->errors = array('tools' => array(sprintf(__('Author %s not found', 'wpomatic'), esc_attr($_REQUEST['campaign_tool_changeauthor']))));
       }
 
       $this->tool_success = __('Posts status updated', 'wpomatic');


### PR DESCRIPTION
The current code generates a PHP Notice-level log message: `PHP Notice:  attribute_escape is <strong>deprecated</strong> since version 2.8! Use esc_attr() instead.`

This PR addresses that Notice. 
